### PR TITLE
Binary queue improvements

### DIFF
--- a/src/cbint/utils/detonation/__init__.py
+++ b/src/cbint/utils/detonation/__init__.py
@@ -2,7 +2,8 @@ __author__ = 'jgarman'
 
 from cbint.utils.daemon import CbIntegrationDaemon, ConfigurationError
 from cbint.utils.detonation.binary_queue import SqliteQueue, SqliteFeedServer
-from cbint.utils.detonation.binary_analysis import (CbAPIProducerThread, CbStreamingProducerThread, QuickScanThread,
+from cbint.utils.detonation.binary_analysis import (CbAPIHistoricalProducerThread, CbAPIUpToDateProducerThread,
+                                                    CbStreamingProducerThread, QuickScanThread,
                                                     DeepAnalysisThread)
 import cbint.utils.feed
 import cbint.utils.cbserver
@@ -197,12 +198,11 @@ class DetonationDaemon(CbIntegrationDaemon):
     def start_binary_collectors(self, filter_spec):
         collectors = []
 
-        collectors.append(CbAPIProducerThread(self.work_queue, self.cb, self.name,
+        collectors.append(CbAPIHistoricalProducerThread(self.work_queue, self.cb, self.name,
                                               sleep_between=self.get_config_integer('sleep_between_batches', 1200),
                                               rate_limiter=0.5,
                                               filter_spec=filter_spec)) # historical query
-        collectors.append(CbAPIProducerThread(self.work_queue, self.cb, self.name,
-                                              max_rows=100,
+        collectors.append(CbAPIUpToDateProducerThread(self.work_queue, self.cb, self.name,
                                               sleep_between=self.get_config_integer('sleep_between_batches', 30),
                                               filter_spec=filter_spec)) # constantly up-to-date query
 

--- a/src/cbint/utils/detonation/__init__.py
+++ b/src/cbint/utils/detonation/__init__.py
@@ -205,7 +205,6 @@ class DetonationDaemon(CbIntegrationDaemon):
                                                         rate_limiter=0.5, start_time=now,
                                                         filter_spec=filter_spec)) # historical query
         collectors.append(CbAPIUpToDateProducerThread(self.work_queue, self.cb, self.name,
-                                                      max_rows=100,
                                                       sleep_between=self.get_config_integer('sleep_between_batches', 30),
                                                       start_time=now,
                                                       filter_spec=filter_spec)) # constantly up-to-date query

--- a/src/cbint/utils/detonation/binary_analysis.py
+++ b/src/cbint/utils/detonation/binary_analysis.py
@@ -81,6 +81,7 @@ class CbAPIProducerThread(threading.Thread):
                           % (str(e), self.sleep_between))
 
             self.queue.set_value(self.start_time_key, cur_timestamp)
+            self.start_time = dateutil.parser.parse(cur_timestamp)
 
             if self.stop_when_done:
                 self.done = True

--- a/src/cbint/utils/detonation/binary_analysis.py
+++ b/src/cbint/utils/detonation/binary_analysis.py
@@ -8,6 +8,7 @@ from zipfile import ZipFile
 from cStringIO import StringIO
 import time
 import logging
+import dateutil.parser
 
 
 log = logging.getLogger(__name__)
@@ -33,7 +34,7 @@ class CbAPIProducerThread(threading.Thread):
 
         now = to_cb_time(datetime.datetime.utcnow())
         self.start_time_key = self.__class__.__name__+'_start_time'
-        self.start_time = self.queue.get_value(self.start_time_key, now)
+        self.start_time = dateutil.parser.parse(self.queue.get_value(self.start_time_key, now))
 
     def stop(self):
         self.done = True

--- a/src/cbint/utils/detonation/binary_analysis.py
+++ b/src/cbint/utils/detonation/binary_analysis.py
@@ -12,6 +12,11 @@ import logging
 
 log = logging.getLogger(__name__)
 
+
+def to_cb_time(dt):
+    return dt.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
+
+
 class CbAPIProducerThread(threading.Thread):
     def __init__(self, work_queue, cb, name, max_rows=None, sleep_between=60, rate_limiter=0.1, stop_when_done=False,
                  filter_spec=''):
@@ -26,16 +31,28 @@ class CbAPIProducerThread(threading.Thread):
         self.stop_when_done = stop_when_done
         self.filter_spec = filter_spec
 
+        now = to_cb_time(datetime.datetime.utcnow())
+        self.start_time_key = self.__class__.__name__+'_start_time'
+        self.start_time = self.queue.get_value(self.start_time_key, now)
+
     def stop(self):
         self.done = True
+
+    @property
+    def query_string(self):
+        return self.filter_spec
+
+    @property
+    def query_sort(self):
+        return "server_added_timestamp desc"
 
     def run(self):
         while not self.done:
             # TODO: retry logic - make sure we don't bomb out if this fails
-            query_string = '-alliance_score_%s %s' % (self.feed_name, self.filter_spec)
-            log.debug("Querying cb for binaries matching '%s'" % query_string)
+            log.debug("Querying cb for binaries matching '%s'" % self.query_string)
             try:
-                for i,binary in enumerate(self.cb.binary_search_iter(query_string, sort="server_added_timestamp desc")):
+                for i, binary in enumerate(self.cb.binary_search_iter(self.query_string,
+                                                                      sort=self.query_sort)):
                     if self.done:
                         return
 
@@ -43,6 +60,8 @@ class CbAPIProducerThread(threading.Thread):
                     if not self.queue.append(binary['md5']):
                         pass
                         # print 'md5 %s already tracked' % (binary['md5'],)
+
+                    self.queue.set_value(self.start_time_key, binary['server_added_timestamp'])
 
                     sleep(self.rate_limiter)        # no need to flood the Cb server or ourselves with binaries
 
@@ -56,6 +75,35 @@ class CbAPIProducerThread(threading.Thread):
                 self.done = True
             else:
                 sleep(self.sleep_between)
+
+
+class CbAPIUpToDateProducerThread(CbAPIProducerThread):
+    def __init__(self, *args, **kwargs):
+        super(CbAPIUpToDateProducerThread, self).__init__(*args, **kwargs)
+
+    @property
+    def query_string(self):
+        if self.start_time:
+            return "server_added_timestamp:[%s TO *] %s" % (to_cb_time(self.start_time), self.filter_spec)
+        else:
+            return self.filter_spec
+
+    @property
+    def query_sort(self):
+        return "server_added_timestamp asc"
+
+
+class CbAPIHistoricalProducerThread(CbAPIProducerThread):
+    @property
+    def query_string(self):
+        if self.start_time:
+            return "server_added_timestamp:[* TO %s] %s" % (to_cb_time(self.start_time), self.filter_spec)
+        else:
+            return self.filter_spec
+
+    @property
+    def query_sort(self):
+        return "server_added_timestamp desc"
 
 
 class CbStreamingProducerThread(QueuedCbSubscriber):

--- a/src/cbint/utils/detonation/binary_analysis.py
+++ b/src/cbint/utils/detonation/binary_analysis.py
@@ -86,7 +86,7 @@ class CbAPIProducerThread(threading.Thread):
 
 class CbAPIUpToDateProducerThread(CbAPIProducerThread):
     def __init__(self, *args, **kwargs):
-        self.default_start_time = kwargs.pop('start_time', None)
+        self.default_start_time = kwargs.pop('start_time', datetime.datetime.utcnow())
         super(CbAPIUpToDateProducerThread, self).__init__(*args, **kwargs)
 
     @property
@@ -105,7 +105,7 @@ class CbAPIUpToDateProducerThread(CbAPIProducerThread):
 
 class CbAPIHistoricalProducerThread(CbAPIProducerThread):
     def __init__(self, *args, **kwargs):
-        self.default_start_time = kwargs.pop('start_time', None)
+        self.default_start_time = kwargs.pop('start_time', datetime.datetime.utcnow())
         super(CbAPIHistoricalProducerThread, self).__init__(*args, **kwargs)
 
     @property

--- a/src/cbint/utils/detonation/binary_analysis.py
+++ b/src/cbint/utils/detonation/binary_analysis.py
@@ -72,6 +72,10 @@ class CbAPIProducerThread(threading.Thread):
 
                     if self.max_rows and i > self.max_rows:
                         break
+
+                    if i % 100 == 0:
+                        self.queue.set_value(self.start_time_key, cur_timestamp)
+
             except Exception as e:
                 log.error("Error during binary enumeration: %s. Sleeping for %f seconds and retrying."
                           % (str(e), self.sleep_between))

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,7 +1,7 @@
 __author__ = 'jgarman'
 
 import unittest
-from cbint.utils.detonation import DetonationDaemon, CbAPIProducerThread
+from cbint.utils.detonation import DetonationDaemon, CbAPIUpToDateProducerThread, CbAPIHistoricalProducerThread
 import os
 import tempfile
 import sys
@@ -64,9 +64,9 @@ class DaemonTest(unittest.TestCase):
         pass
 
     def test_binary_collectors(self):
-        CbAPIProducerThread(self.daemon.work_queue, self.daemon.cb, self.daemon.name, rate_limiter=0,
+        CbAPIHistoricalProducerThread(self.daemon.work_queue, self.daemon.cb, self.daemon.name, rate_limiter=0,
                             stop_when_done=True).run()
-        cb_total = self.daemon.cb.binary_search('')['total_results']
+        cb_total = self.daemon.cb.binary_search('', rows=1000)['total_results']
         self.assertEquals(self.daemon.work_queue.number_unanalyzed(), cb_total)
 
     def test_empty(self):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -5,13 +5,18 @@ from cbint.utils.detonation import DetonationDaemon, CbAPIUpToDateProducerThread
 import os
 import tempfile
 import sys
-import multiprocessing
 import threading
 import socket
 from time import sleep
+import dateutil.parser
+import logging
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 from utils.mock_server import get_mocked_server
+
+logging.basicConfig()
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
 
 
 class TestDaemon(DetonationDaemon):
@@ -64,8 +69,18 @@ class DaemonTest(unittest.TestCase):
         pass
 
     def test_binary_collectors(self):
-        CbAPIHistoricalProducerThread(self.daemon.work_queue, self.daemon.cb, self.daemon.name, rate_limiter=0,
-                            stop_when_done=True).run()
+        now = dateutil.parser.parse('2015-07-01')
+        historical_producer = CbAPIHistoricalProducerThread(self.daemon.work_queue, self.daemon.cb, self.daemon.name,
+                                                            rate_limiter=0, stop_when_done=True, start_time=now)
+        historical_producer.run()
+
+        up_to_date_producer = CbAPIUpToDateProducerThread(self.daemon.work_queue, self.daemon.cb, self.daemon.name,
+                                                          rate_limiter=0, stop_when_done=True, start_time=now)
+        up_to_date_producer.run()
+
+        log.info('earliest binary: %s' % self.daemon.work_queue.get_value('CbAPIHistoricalProducerThread_start_time'))
+        log.info('latest binary  : %s' % self.daemon.work_queue.get_value('CbAPIUpToDateProducerThread_start_time'))
+
         cb_total = self.daemon.cb.binary_search('', rows=1000)['total_results']
         self.assertEquals(self.daemon.work_queue.number_unanalyzed(), cb_total)
 

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -63,18 +63,17 @@ def get_mocked_server(binary_directory):
 
     def binary_search(q, rows, start, sort_string):
         # we only support 'q' on server_added_timestamp
-        log.info("typeof(q) = %s" % q.__class__.__name__)
         matches = filter_re.search(q)
         if not matches:
             filtered_binaries = binaries
         else:
             if matches.group(1) == '*':
                 limit = dateutil.parser.parse(matches.group(2))
-                filtered_binaries = filter(lambda x: dateutil.parser.parse(x['server_added_timestamp']) <= limit,
+                filtered_binaries = filter(lambda x: dateutil.parser.parse(x['server_added_timestamp']).replace(tzinfo=None) <= limit,
                                            binaries)
             else:
                 limit = dateutil.parser.parse(matches.group(1))
-                filtered_binaries = filter(lambda x: dateutil.parser.parse(x['server_added_timestamp']) > limit,
+                filtered_binaries = filter(lambda x: dateutil.parser.parse(x['server_added_timestamp']).replace(tzinfo=None) > limit,
                                            binaries)
 
         (field, direction) = sort_string.split()

--- a/tests/utils/mock_server.py
+++ b/tests/utils/mock_server.py
@@ -9,17 +9,25 @@ except ImportError:
 from flask import Flask, request, make_response, Response
 from cStringIO import StringIO
 import zipfile
+import re
+import dateutil.parser
+
+
+log = logging.getLogger(__name__)
 
 
 def get_mocked_server(binary_directory):
     mocked_cb_server = Flask('cb')
 
     files = os.listdir(binary_directory)
+    binaries = [json.load(open(os.path.join(binary_directory, fn), 'r')) for fn in files]
+    filter_re = re.compile("server_added_timestamp:\[(.*) TO (.*)\]")
 
     @mocked_cb_server.route('/api/v1/binary', methods=['GET', 'POST'])
     def binary_search_endpoint():
         if request.method == 'GET':
             query_string = request.args.get('q', '')
+            sort_string = request.args.get('sort', 'server_added_timestamp desc')
             rows = int(request.args.get('rows', 10))
             start = int(request.args.get('start', 0))
         elif request.method == 'POST':
@@ -38,18 +46,49 @@ def get_mocked_server(binary_directory):
                 start = int(parsed_data['start'])
             else:
                 start = 0
+
+            if 'sort' in parsed_data:
+                sort_string = parsed_data['sort']
+            else:
+                sort_string = 'server_added_timestamp desc'
+
         else:
             return make_response('Invalid Request', 500)
 
-        return Response(response=json.dumps(binary_search(query_string, rows, start)),
+        if type(query_string) == list:
+            query_string = query_string[0]
+
+        return Response(response=json.dumps(binary_search(query_string, rows, start, sort_string)),
                         mimetype='application/json')
 
-    def binary_search(q, rows, start):
+    def binary_search(q, rows, start, sort_string):
+        # we only support 'q' on server_added_timestamp
+        log.info("typeof(q) = %s" % q.__class__.__name__)
+        matches = filter_re.search(q)
+        if not matches:
+            filtered_binaries = binaries
+        else:
+            if matches.group(1) == '*':
+                limit = dateutil.parser.parse(matches.group(2))
+                filtered_binaries = filter(lambda x: dateutil.parser.parse(x['server_added_timestamp']) <= limit,
+                                           binaries)
+            else:
+                limit = dateutil.parser.parse(matches.group(1))
+                filtered_binaries = filter(lambda x: dateutil.parser.parse(x['server_added_timestamp']) > limit,
+                                           binaries)
+
+        (field, direction) = sort_string.split()
+        if direction == 'asc':
+            reverse = False
+        else:
+            reverse = True
+
+        sorted_binaries = sorted(filtered_binaries, key=lambda x: x[field], reverse=reverse)[start:start+rows]
+
         return {
-            'results':
-                [json.load(open(os.path.join(binary_directory, fn), 'r')) for fn in files[start:start+rows]],
+            'results': sorted_binaries,
             'terms': '',
-            'total_results': len(files),
+            'total_results': len(sorted_binaries),
             'start': start,
             'elapsed': 0.1,
             'highlights': [],


### PR DESCRIPTION
Two major changes:
1. Change the Producer classes to use `server_added_timestamp` as a filter for selecting binaries to add to the analysis queue rather than filtering on whether the binary has a score for this feed. This eliminates the need for binaries to have "zero" scores just to mark that they've been analyzed, which brings to point two...
2. Remove binaries that have been analyzed but did not hit on the binary detonation provider ("zero" hits) from the feed generated for the Cb server
