### PR TITLE
Timestamp fixes

### DIFF
--- a/src/cbint/utils/detonation/binary_analysis.py
+++ b/src/cbint/utils/detonation/binary_analysis.py
@@ -209,7 +209,7 @@ class BinaryConsumerThread(threading.Thread):
         if type(e) == AnalysisTemporaryError:
             retry_in_seconds = int(e.retry_in)
             self.database_arbiter.mark_as_analyzed(md5sum, False, e.analysis_version, e.message, e.extended_message,
-                                                   retry_at=datetime.datetime.now()+datetime.timedelta(seconds=retry_in_seconds))
+                                                   retry_at=datetime.datetime.utcnow()+datetime.timedelta(seconds=retry_in_seconds))
             log.error("Temporary error analyzing md5sum %s: %s (%s). Will retry in %d seconds." % (md5sum,
                                                                                                    e.message,
                                                                                                    e.extended_message,

--- a/src/cbint/utils/detonation/binary_queue.py
+++ b/src/cbint/utils/detonation/binary_queue.py
@@ -381,13 +381,12 @@ class SqliteQueue(object):
             new_timestamp = []
             for i in range(1, 5):
                 dt = None
-                try:
-                    dt = dateutil.parser.parse(row[i])
-                    dt += time_shift
-                except ValueError:
-                    pass
-                except Exception as e:
-                    log.exception("Could not convert %s to date/time stamp for md5sum %s" % (row[i], row[0]))
+                if row[i] is not None:
+                    try:
+                        dt = dateutil.parser.parse(row[i])
+                        dt += time_shift
+                    except Exception as e:
+                        log.exception("Could not convert %s to date/time stamp for md5sum %s" % (row[i], row[0]))
 
                 new_timestamp.append(dt)
             conn.execute("UPDATE binary_data SET last_modified = ?, inserted_at = ?, next_attempt_at = ?, binary_available_since = ? WHERE md5sum = ?",

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -31,7 +31,7 @@ class ConsumerThread(threading.Thread):
             if random.random() < 0.1:
                 # we errored out!
                 self.arbiter.mark_as_analyzed(md5sum, False, 1, "Error", "Longer error message",
-                                              retry_at=datetime.datetime.now() + datetime.timedelta(seconds=10))
+                                              retry_at=datetime.datetime.utcnow() + datetime.timedelta(seconds=10))
                 self.errors.append(md5sum)
             else:
                 self.arbiter.set_binary_available(md5sum)


### PR DESCRIPTION
Timestamps should be stored relative to GMT+0, not in localtime. This patch changes all time management code to use GMT rather than local time in the database, and will attempt to fix up existing timestamps to GMT.

The fixup code has various edge cases that we can't easily handle, notably if the database contains timestamps from several different local time zones (or the same time zone with and without DST) the resulting database will have some timestamps with incorrect times. All new timestamps will be correct, however.
